### PR TITLE
Remove util dependency

### DIFF
--- a/lib/color-harmony.js
+++ b/lib/color-harmony.js
@@ -9,7 +9,6 @@
 'use strict';
 
 var onecolor = require('onecolor');
-var util = require('util');
 
 var Harmonizer = function () {
 	var api = this;
@@ -82,7 +81,7 @@ var Harmonizer = function () {
 	};
 
 	api.add = function (harmonyName, degreeArray) {
-		if (util.isArray(degreeArray)) {
+		if (Array.isArray(degreeArray)) {
 			harmonies[harmonyName] = degreeArray;
 		}
 	};
@@ -103,7 +102,7 @@ var Harmonizer = function () {
 		if (harmonies.hasOwnProperty(harmony)) {
 			harmony = harmonies[harmony];
 		}
-		if (util.isArray(harmony)) {
+		if (Array.isArray(harmony)) {
 			return harmonize(color, harmony);
 		} else {
 			return [];


### PR DESCRIPTION
Hey, great module! :) I was wondering if you’d consider removing the util dependency? Reason being, it adds ~20kb to the bundle, and the only method being used, `isArray`, can be [polyfilled](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray#Polyfill) in a couple of lines.
